### PR TITLE
feat: add cardinality check on arbitrary set generation

### DIFF
--- a/src/random/arbitrary/arbitrary/arbitrary.ts
+++ b/src/random/arbitrary/arbitrary/arbitrary.ts
@@ -11,6 +11,7 @@ import { splitX, splits } from '../shrink/shrink.js'
 
 export interface Arbitrary<T> {
     value: (context: ArbitraryContext) => Tree<T>
+    supremumCardinality?: ((context: ArbitraryContext) => number) | undefined
 }
 
 export type AsArbitrary<T extends ArbitraryOrLiteral<unknown>> = T extends readonly unknown[]

--- a/src/random/arbitrary/dependent/dependent.ts
+++ b/src/random/arbitrary/dependent/dependent.ts
@@ -20,9 +20,12 @@ export interface Dependent<T> extends Arbitrary<T> {
 /**
  * @internal
  */
-export function dependentArbitrary<T>(f: (context: ArbitraryContext) => Tree<T>): Dependent<T> {
+export function dependentArbitrary<T>(
+    f: (context: ArbitraryContext) => Tree<T>,
+    { supremumCardinality }: Pick<Dependent<unknown>, 'supremumCardinality'> = {},
+): Dependent<T> {
     let localContext: ArbitraryContext | undefined
-    const dependent = {
+    const dependent: Dependent<T> = {
         sample: (context: ArbitraryContext) => f(context).value,
         value: (context: ArbitraryContext) => f(context),
         // biome-ignore lint/suspicious/noAssignInExpressions: This is a valid use case for assignment in expressions
@@ -31,6 +34,7 @@ export function dependentArbitrary<T>(f: (context: ArbitraryContext) => Tree<T>)
         map: <U>(fn: (x: T, context: ArbitraryContext) => U) => mapArbitrary(dependent, fn),
         chain: <U>(fn: (x: T, context: ArbitraryContext) => Arbitrary<U>) => chainArbitrary(dependent, fn),
         constant: () => constantArbitrary(dependent),
-    }
+        supremumCardinality,
+    } satisfies Dependent<T>
     return dependent
 }

--- a/src/random/arbitrary/integrated/integrated.ts
+++ b/src/random/arbitrary/integrated/integrated.ts
@@ -29,11 +29,13 @@ export function integratedArbitrary<C, T>({
     shrink,
     constraints,
     biased,
+    supremumCardinality,
 }: {
     sample: (constraints: C, context: ArbitraryContext) => T
     shrink: (constraints: C, x: T) => Tree<T>
     constraints: C
     biased?: (constraints: C, context: BiasedArbitraryContext) => C
+    supremumCardinality?: ((context: ArbitraryContext) => number) | undefined
 }): Integrated<C, T> {
     let localContext: ArbitraryContext | undefined
     const biasedSample =
@@ -64,6 +66,7 @@ export function integratedArbitrary<C, T>({
         map: <U>(fn: (x: T, context: ArbitraryContext) => U) => mapArbitrary(integrated, fn),
         chain: <U>(fn: (x: T, context: ArbitraryContext) => Arbitrary<U>) => chainArbitrary(integrated, fn),
         constant: () => constantArbitrary(integrated),
+        supremumCardinality,
     } satisfies Integrated<C, T>
 
     return integrated

--- a/src/random/arbitrary/transform/transform.ts
+++ b/src/random/arbitrary/transform/transform.ts
@@ -9,7 +9,9 @@ import type { Dependent } from '../dependent/index.js'
  * @internal
  */
 export function mapArbitrary<T, U>(a: Arbitrary<T>, f: (x: T, context: ArbitraryContext) => U): Dependent<U> {
-    return dependentArbitrary((context) => mapTree(a.value(context), (v) => f(v, context)))
+    return dependentArbitrary((context) => mapTree(a.value(context), (v) => f(v, context)), {
+        supremumCardinality: a.supremumCardinality,
+    })
 }
 
 /**

--- a/src/random/types/array/array.spec.ts
+++ b/src/random/types/array/array.spec.ts
@@ -9,7 +9,8 @@ import { natural } from '../index.js'
 import { integer } from '../integer/index.js'
 import { tuple } from '../tuple/tuple.js'
 
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { arbitraryContext } from '../../arbitrary/context/context.js'
 
 describe('array', () => {
     it('simple', () => {
@@ -91,5 +92,9 @@ describe('array', () => {
             },
             { seed: 42n },
         )
+    })
+
+    it('cardinality', () => {
+        expect(array(integer()).supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('42949672970')
     })
 })

--- a/src/random/types/boolean/boolean.spec.ts
+++ b/src/random/types/boolean/boolean.spec.ts
@@ -53,3 +53,7 @@ it('counter example - false', () => {
       ]
     `)
 })
+
+it('cardinality', () => {
+    expect(boolean().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('2')
+})

--- a/src/random/types/boolean/boolean.ts
+++ b/src/random/types/boolean/boolean.ts
@@ -26,5 +26,10 @@ function shrinkBoolean(_: undefined, x: boolean): Tree<boolean> {
  * @group Arbitrary
  */
 export function boolean(): Integrated<undefined, boolean> {
-    return integratedArbitrary({ sample: sampleBoolean, shrink: shrinkBoolean, constraints: undefined })
+    return integratedArbitrary({
+        sample: sampleBoolean,
+        shrink: shrinkBoolean,
+        constraints: undefined,
+        supremumCardinality: () => 2,
+    })
 }

--- a/src/random/types/char/char.spec.ts
+++ b/src/random/types/char/char.spec.ts
@@ -14,9 +14,10 @@ import {
 import { forAll } from '../../arbitrary/index.js'
 import { utf16 } from '../string/index.js'
 
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import util from 'node:util'
+import { arbitraryContext } from '../../arbitrary/context/context.js'
 
 const isPrintable = (str: string) => /^[ -~]+$/.test(str)
 
@@ -32,6 +33,10 @@ describe('char', () => {
     it('all printable', () => {
         forAll(char(), isPrintable)
     })
+
+    it('cardinality', () => {
+        expect(char().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('95')
+    })
 })
 
 describe('hexChar', () => {
@@ -46,6 +51,10 @@ describe('hexChar', () => {
     it('all printable', () => {
         forAll(hexChar(), isPrintable)
     })
+
+    it('cardinality', () => {
+        expect(hexChar().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('16')
+    })
 })
 
 describe('base64Char', () => {
@@ -59,6 +68,10 @@ describe('base64Char', () => {
 
     it('all printable', () => {
         forAll(base64Char(), isPrintable)
+    })
+
+    it('cardinality', () => {
+        expect(base64Char().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('64')
     })
 })
 
@@ -81,6 +94,10 @@ describe('alphaChar', () => {
     it('all printable', () => {
         forAll(alphaChar(), isPrintable)
     })
+
+    it('cardinality', () => {
+        expect(alphaChar().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('52')
+    })
 })
 
 describe('lowerAlphaChar', () => {
@@ -101,6 +118,10 @@ describe('lowerAlphaChar', () => {
 
     it('all printable', () => {
         forAll(lowerAlphaChar(), isPrintable)
+    })
+
+    it('cardinality', () => {
+        expect(lowerAlphaChar().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('25')
     })
 })
 
@@ -123,6 +144,10 @@ describe('alphaNumericChar', () => {
     it('all printable', () => {
         forAll(alphaNumericChar(), isPrintable)
     })
+
+    it('cardinality', () => {
+        expect(alphaNumericChar().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('62')
+    })
 })
 
 describe('lowerAlphaNumericChar', () => {
@@ -144,6 +169,10 @@ describe('lowerAlphaNumericChar', () => {
     it('all printable', () => {
         forAll(lowerAlphaNumericChar(), isPrintable)
     })
+
+    it('cardinality', () => {
+        expect(lowerAlphaNumericChar().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('36')
+    })
 })
 
 describe('asciiChar', () => {
@@ -155,6 +184,10 @@ describe('asciiChar', () => {
         // biome-ignore lint/suspicious/noControlCharactersInRegex: This is intentional
         forAll(asciiChar(), (c) => /[\x00-\x7F]/.test(c))
     })
+
+    it('cardinality', () => {
+        expect(asciiChar().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('127')
+    })
 })
 
 describe('utf16Char', () => {
@@ -165,6 +198,10 @@ describe('utf16Char', () => {
     it('allowed characters', () => {
         forAll(utf16Char(), (c) => util.toUSVString(c) === c)
     })
+
+    it('cardinality', () => {
+        expect(utf16Char().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('65536')
+    })
 })
 
 describe('utf16SurrogateChar', () => {
@@ -174,5 +211,9 @@ describe('utf16SurrogateChar', () => {
 
     it('allowed characters', () => {
         forAll(utf16SurrogateChar(), (c) => util.toUSVString(c) === c)
+    })
+
+    it('cardinality', () => {
+        expect(utf16SurrogateChar().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('1114112')
     })
 })

--- a/src/random/types/char/char.ts
+++ b/src/random/types/char/char.ts
@@ -1,6 +1,4 @@
-import { mapTree } from '../../../algorithm/tree/index.js'
 import type { Dependent } from '../../arbitrary/dependent/index.js'
-import { dependentArbitrary } from '../../arbitrary/dependent/index.js'
 import { element } from '../element/index.js'
 import { integer } from '../integer/index.js'
 
@@ -34,8 +32,7 @@ export interface CharGenerator {
  */
 export function charGenerator(context: Partial<CharGenerator> = {}): Dependent<string> {
     const { min = 32, max = 126, transform = String.fromCharCode } = context
-    const int = integer({ min, max })
-    return dependentArbitrary((ctx) => mapTree(int.value(ctx), (i) => transform(i)))
+    return integer({ min, max }).map((i) => transform(i))
 }
 
 function toAscii(x: number): string {

--- a/src/random/types/constants/constants.spec.ts
+++ b/src/random/types/constants/constants.spec.ts
@@ -1,4 +1,5 @@
-import { expectTypeOf, it } from 'vitest'
+import { expect, expectTypeOf, it } from 'vitest'
+import { arbitraryContext } from '../../arbitrary/context/context.js'
 import type { Dependent } from '../../arbitrary/dependent/dependent.js'
 import { forAll, random } from '../../arbitrary/index.js'
 import { object } from '../object/index.js'
@@ -18,4 +19,8 @@ it('simple', () => {
 
 it('has the correct types', () => {
     expectTypeOf(constants('foo', 'bar')).toEqualTypeOf<Dependent<'foo' | 'bar'>>()
+})
+
+it('cardinality', () => {
+    expect(constants('foo', 'bar').supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('2')
 })

--- a/src/random/types/date/date.spec.ts
+++ b/src/random/types/date/date.spec.ts
@@ -60,6 +60,10 @@ describe('datetime', () => {
           ]
         `)
     })
+
+    it('cardinality', () => {
+        expect(datetime().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('8640000000001')
+    })
 })
 
 describe('date', () => {
@@ -87,5 +91,9 @@ describe('date', () => {
             "2010-10-08",
           ]
         `)
+    })
+
+    it('cardinality', () => {
+        expect(date().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('8640000000001')
     })
 })

--- a/src/random/types/date/date.ts
+++ b/src/random/types/date/date.ts
@@ -1,7 +1,5 @@
-import { mapTree } from '../../../algorithm/tree/index.js'
 import type { MaybePartial } from '../../../type/partial/partial.js'
 import type { Dependent } from '../../arbitrary/dependent/index.js'
-import { dependentArbitrary } from '../../arbitrary/dependent/index.js'
 import { integer } from '../integer/index.js'
 
 /**
@@ -82,25 +80,22 @@ export interface DatetimeGenerator {
  */
 export function datetime(context: MaybePartial<DatetimeGenerator> = {}): Dependent<Date> {
     const { minDate: minDatetime, maxDate: maxDatetime, precision = 'seconds', range = 'relevant' } = context
-    const atimestamp = timestamp({ min: minDatetime?.getTime(), max: maxDatetime?.getTime(), range })
-    return dependentArbitrary((ctx) =>
-        mapTree(atimestamp.value(ctx), (i) => {
-            const d = new Date(i)
-            if (!['milliseconds'].includes(precision)) {
-                d.setMilliseconds(0)
-            }
-            if (!['milliseconds', 'seconds'].includes(precision)) {
-                d.setSeconds(0)
-            }
-            if (!['milliseconds', 'seconds', 'minutes'].includes(precision)) {
-                d.setMinutes(0)
-            }
-            if (!['milliseconds', 'seconds', 'minutes', 'hours'].includes(precision)) {
-                d.setHours(0)
-            }
-            return d
-        }),
-    )
+    return timestamp({ min: minDatetime?.getTime(), max: maxDatetime?.getTime(), range }).map((i) => {
+        const d = new Date(i)
+        if (!['milliseconds'].includes(precision)) {
+            d.setMilliseconds(0)
+        }
+        if (!['milliseconds', 'seconds'].includes(precision)) {
+            d.setSeconds(0)
+        }
+        if (!['milliseconds', 'seconds', 'minutes'].includes(precision)) {
+            d.setMinutes(0)
+        }
+        if (!['milliseconds', 'seconds', 'minutes', 'hours'].includes(precision)) {
+            d.setHours(0)
+        }
+        return d
+    })
 }
 
 export interface DateGenerator {
@@ -125,11 +120,11 @@ export interface DateGenerator {
  */
 export function date(constraints: MaybePartial<DateGenerator> = {}): Dependent<string> {
     const { minDate, maxDate, range = 'relevant' } = constraints
-    const atimestamp = datetime({
+
+    return datetime({
         minDate: minDate !== undefined ? new Date(minDate) : undefined,
         maxDate: maxDate !== undefined ? new Date(maxDate) : undefined,
         range,
         precision: 'days',
-    })
-    return dependentArbitrary((ctx) => mapTree(atimestamp.value(ctx), (d) => d.toISOString().slice(0, 10)))
+    }).map((d) => d.toISOString().slice(0, 10))
 }

--- a/src/random/types/element/element.ts
+++ b/src/random/types/element/element.ts
@@ -1,6 +1,4 @@
-import { mapTree } from '../../../algorithm/tree/index.js'
 import type { Dependent } from '../../arbitrary/dependent/index.js'
-import { dependentArbitrary } from '../../arbitrary/dependent/index.js'
 import { integer } from '../integer/index.js'
 
 /**
@@ -25,6 +23,5 @@ import { integer } from '../integer/index.js'
 export function element<T extends unknown[] | string>(
     elements: T extends string ? string : T,
 ): Dependent<T extends string ? string : T[number]> {
-    const aint = integer({ min: 0, max: elements.length - 1 })
-    return dependentArbitrary((context) => mapTree(aint.value(context), (n) => elements[n] as T extends string ? string : T))
+    return integer({ min: 0, max: elements.length - 1 }).map((n) => elements[n] as T extends string ? string : T)
 }

--- a/src/random/types/helper/helper.ts
+++ b/src/random/types/helper/helper.ts
@@ -123,7 +123,7 @@ export function nullable<T>(a: Arbitrary<T>, constraints: MaybePartial<NullableG
  * @group Arbitrary
  */
 export function constant<const T>(x: T): Dependent<T> {
-    return dependentArbitrary(() => ({ value: x, children: [] }))
+    return dependentArbitrary(() => ({ value: x, children: [] }), { supremumCardinality: () => 1 })
 }
 
 export function memoizeArbitrary<T>(arb: () => Arbitrary<T>): Dependent<T> {

--- a/src/random/types/integer/integer.spec.ts
+++ b/src/random/types/integer/integer.spec.ts
@@ -399,3 +399,7 @@ it('random sample', () => {
       ]
     `)
 })
+
+it('cardinality', () => {
+    expect(integer({ min: 0, max: 1000 }).supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('1001')
+})

--- a/src/random/types/integer/integer.ts
+++ b/src/random/types/integer/integer.ts
@@ -121,5 +121,6 @@ export function integer({
             min,
             max,
         },
+        supremumCardinality: () => max - min + 1,
     })
 }

--- a/src/random/types/object/object.spec.ts
+++ b/src/random/types/object/object.spec.ts
@@ -8,25 +8,25 @@ import { arbitraryContext } from '../../arbitrary/context/context.js'
 import { forAll } from '../../arbitrary/forall/forall.js'
 import { xoroshiro128plus } from '../../rng/index.js'
 import { json } from '../complex/index.js'
-import { optional } from '../helper/helper.js'
+import { constant, optional } from '../helper/helper.js'
 import { integer } from '../integer/index.js'
 import { oneOf } from '../one-of/index.js'
 import { utf16 } from '../string/index.js'
 
-import { describe, expect, it } from 'vitest'
+import { expect, it } from 'vitest'
+import { constants } from '../constants/constants.js'
 
-describe('object', () => {
-    it('random sample', () => {
-        const ctx = arbitraryContext({ rng: xoroshiro128plus(1638968569864n) })
-        const aint = object({ foo: integer() })
-        expect(
-            collect(
-                take(
-                    repeat(() => aint.sample(ctx)),
-                    10,
-                ),
+it('random sample', () => {
+    const ctx = arbitraryContext({ rng: xoroshiro128plus(1638968569864n) })
+    const aint = object({ foo: integer() })
+    expect(
+        collect(
+            take(
+                repeat(() => aint.sample(ctx)),
+                10,
             ),
-        ).toMatchInlineSnapshot(`
+        ),
+    ).toMatchInlineSnapshot(`
           [
             {
               "foo": 218084956,
@@ -60,30 +60,30 @@ describe('object', () => {
             },
           ]
         `)
-    })
+})
 
-    it('foo', () => {
-        const aobject = object({
-            foo: oneOf(utf16(), integer()),
-            bar: utf16(),
-        })
-        expect(aobject.random(arbitraryContext({ rng: xoroshiro128plus(42n) }))).toMatchInlineSnapshot(`
+it('foo', () => {
+    const aobject = object({
+        foo: oneOf(utf16(), integer()),
+        bar: utf16(),
+    })
+    expect(aobject.random(arbitraryContext({ rng: xoroshiro128plus(42n) }))).toMatchInlineSnapshot(`
           {
             "bar": "䈞",
             "foo": "",
           }
         `)
-    })
+})
 
-    it('foo2', () => {
-        const aobject = object({
+it('foo2', () => {
+    const aobject = object({
+        foo: oneOf(utf16(), integer()),
+        bar: object({
             foo: oneOf(utf16(), integer()),
-            bar: object({
-                foo: oneOf(utf16(), integer()),
-                bar: utf16(),
-            }),
-        })
-        expect(aobject.random(arbitraryContext({ rng: xoroshiro128plus(42n) }))).toMatchInlineSnapshot(`
+            bar: utf16(),
+        }),
+    })
+    expect(aobject.random(arbitraryContext({ rng: xoroshiro128plus(42n) }))).toMatchInlineSnapshot(`
           {
             "bar": {
               "bar": "脄釜",
@@ -92,11 +92,11 @@ describe('object', () => {
             "foo": "",
           }
         `)
-    })
+})
 
-    it('foo3', () => {
-        const aobject = json()
-        expect(aobject.value(arbitraryContext({ rng: xoroshiro128plus(48n) })).value).toMatchInlineSnapshot(`
+it('foo3', () => {
+    const aobject = json()
+    expect(aobject.value(arbitraryContext({ rng: xoroshiro128plus(48n) })).value).toMatchInlineSnapshot(`
           {
             "": false,
             ",V^?/": false,
@@ -110,29 +110,29 @@ describe('object', () => {
             "w": true,
           }
         `)
-    })
+})
 
-    it('foo4', () => {
-        const aobject = object({})
-        expect(aobject.random(arbitraryContext({ rng: xoroshiro128plus(42n) }))).toMatchInlineSnapshot('{}')
-    })
+it('foo4', () => {
+    const aobject = object({})
+    expect(aobject.random(arbitraryContext({ rng: xoroshiro128plus(42n) }))).toMatchInlineSnapshot('{}')
+})
 
-    it('shrinks down on all properties', () => {
-        expect(() => {
-            forAll(
-                object({
-                    foo1: optional(integer(), { symbol: undefined }),
-                    foo2: optional(integer(), { symbol: undefined }),
-                    foo3: optional(integer(), { symbol: undefined }),
-                    foo4: optional(integer(), { symbol: undefined }),
-                    foo5: optional(integer(), { symbol: undefined }),
-                    foo6: optional(integer(), { symbol: undefined }),
-                    foo7: optional(integer(), { symbol: undefined }),
-                }).map(omitUndefined),
-                (i) => Object.values(i).every((x) => x === undefined),
-                { seed: 42n, timeout: false },
-            )
-        }).toThrowErrorMatchingInlineSnapshot(`
+it('shrinks down on all properties', () => {
+    expect(() => {
+        forAll(
+            object({
+                foo1: optional(integer(), { symbol: undefined }),
+                foo2: optional(integer(), { symbol: undefined }),
+                foo3: optional(integer(), { symbol: undefined }),
+                foo4: optional(integer(), { symbol: undefined }),
+                foo5: optional(integer(), { symbol: undefined }),
+                foo6: optional(integer(), { symbol: undefined }),
+                foo7: optional(integer(), { symbol: undefined }),
+            }).map(omitUndefined),
+            (i) => Object.values(i).every((x) => x === undefined),
+            { seed: 42n, timeout: false },
+        )
+    }).toThrowErrorMatchingInlineSnapshot(`
           [AssertionError: Counter example found after 2 tests (seed: 42n)
           Shrunk 1 time(s)
           Counter example:
@@ -141,5 +141,16 @@ describe('object', () => {
 
           ]
         `)
-    })
+})
+
+it('cardinality', () => {
+    expect(
+        object({ foo: constant('foo'), bar: constant('bar') }).supremumCardinality?.(arbitraryContext()),
+    ).toMatchInlineSnapshot('1')
+    expect(
+        object({ foo: constants('foo', 'bar'), bar: constant('bar') }).supremumCardinality?.(arbitraryContext()),
+    ).toMatchInlineSnapshot('2')
+    expect(
+        object({ foo: constants('foo', 'bar'), bar: constants('foo', 'bar') }).supremumCardinality?.(arbitraryContext()),
+    ).toMatchInlineSnapshot('4')
 })

--- a/src/random/types/object/object.ts
+++ b/src/random/types/object/object.ts
@@ -1,7 +1,6 @@
 import type { Arbitrary } from '../../arbitrary/arbitrary/index.js'
 import type { ArbitraryContext } from '../../arbitrary/context/index.js'
 import type { Dependent } from '../../arbitrary/dependent/index.js'
-import { dependentArbitrary } from '../../arbitrary/dependent/index.js'
 import { constant } from '../helper/index.js'
 import { tuple } from '../tuple/index.js'
 
@@ -30,7 +29,7 @@ export function object<T extends Record<PropertyKey, Arbitrary<unknown>>>(
 ): Dependent<{ [K in keyof T]: T[K] extends { value(context: ArbitraryContext): { value: infer Value } } ? Value : never }> {
     const keys = Object.keys(properties)
     if (keys.length === 0) {
-        return dependentArbitrary((context) => constant({}).value(context)) as Dependent<{
+        return constant({}) as Dependent<{
             [K in keyof T]: T[K] extends { value(context: ArbitraryContext): { value: infer Value } } ? Value : never
         }>
     }

--- a/src/random/types/one-of/one-of.spec.ts
+++ b/src/random/types/one-of/one-of.spec.ts
@@ -408,6 +408,10 @@ describe('oneOf', () => {
         expectTypeOf(oneOf(integer(), string())).toEqualTypeOf<Dependent<number | string>>()
         expectTypeOf(oneOf(constant('foo'), constant('bar'))).toEqualTypeOf<Dependent<'foo' | 'bar'>>()
     })
+
+    it('cardinality', () => {
+        expect(oneOf(integer(), string()).supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('4294968247')
+    })
 })
 
 describe('oneOfWeighted', () => {

--- a/src/random/types/one-of/one-of.ts
+++ b/src/random/types/one-of/one-of.ts
@@ -1,5 +1,6 @@
 import type { Arbitrary, TypeOfArbitraries } from '../../arbitrary/arbitrary/index.js'
 import { type ArbitrarySize, depthArbitrary } from '../../arbitrary/arbitrary/size.js'
+import type { ArbitraryContext } from '../../arbitrary/context/context.js'
 import { dependentArbitrary } from '../../arbitrary/dependent/dependent.js'
 import type { Dependent } from '../../arbitrary/dependent/index.js'
 import { weightedChoice } from '../choice/choice.js'
@@ -55,15 +56,23 @@ export function oneOf<T extends Arbitrary<unknown>[]>(...arbitraries: [...T]): D
 export function oneOfWeighted<T extends readonly [number, Arbitrary<unknown>][]>(
     ...arbitraries: [...T]
 ): Dependent<ReturnType<[...T][number][1]['value']>['value']> {
+    // we are drawing from the union of sets, our best guess is to assume no overlap in the cardinality
+    const supremumCardinality = arbitraries.every((x) => x[1].supremumCardinality !== undefined)
+        ? // biome-ignore lint/style/noNonNullAssertion: checked in the line above
+          (ctx: ArbitraryContext) => arbitraries.reduce((acc, x) => acc + x[1].supremumCardinality!(ctx), 0)
+        : undefined
     const choices = weightedChoice(arbitraries)
-    return dependentArbitrary((ctx) => {
-        const selector = float({ min: 0, max: 1 })
+    return dependentArbitrary(
+        (ctx) => {
+            const selector = float({ min: 0, max: 1 })
 
-        return ctx.withDepth(() => {
-            const x = selector.sample(ctx)
-            const depth = depthArbitrary({ context: ctx })
-            const addedZeroWeight = Math.floor((1 + depth) ** ctx.depthCounter) - 1
-            return choices(x * (1 + addedZeroWeight) - addedZeroWeight).value(ctx)
-        })
-    })
+            return ctx.withDepth(() => {
+                const x = selector.sample(ctx)
+                const depth = depthArbitrary({ context: ctx })
+                const addedZeroWeight = Math.floor((1 + depth) ** ctx.depthCounter) - 1
+                return choices(x * (1 + addedZeroWeight) - addedZeroWeight).value(ctx)
+            })
+        },
+        { supremumCardinality },
+    )
 }

--- a/src/random/types/record/record.spec.ts
+++ b/src/random/types/record/record.spec.ts
@@ -7,20 +7,20 @@ import { arbitraryContext } from '../../arbitrary/context/context.js'
 import { xoroshiro128plus } from '../../rng/index.js'
 import { string } from '../string/index.js'
 
-import { describe, expect, it } from 'vitest'
+import { expect, it } from 'vitest'
+import { constant } from '../helper/helper.js'
 
-describe('record', () => {
-    it('random sample', () => {
-        const ctx = arbitraryContext({ rng: xoroshiro128plus(1638968569864n) })
-        const aint = record(string())
-        expect(
-            collect(
-                take(
-                    repeat(() => aint.sample(ctx)),
-                    10,
-                ),
+it('random sample', () => {
+    const ctx = arbitraryContext({ rng: xoroshiro128plus(1638968569864n) })
+    const aint = record(string())
+    expect(
+        collect(
+            take(
+                repeat(() => aint.sample(ctx)),
+                10,
             ),
-        ).toMatchInlineSnapshot(`
+        ),
+    ).toMatchInlineSnapshot(`
           [
             {
               "#'E1.9e+": "z^<)",
@@ -80,5 +80,10 @@ describe('record', () => {
             },
           ]
         `)
-    })
+})
+
+it('cardinality', () => {
+    expect(record([constant('foo'), constant('bar')]).supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot(
+        'undefined',
+    )
 })

--- a/src/random/types/record/record.ts
+++ b/src/random/types/record/record.ts
@@ -27,7 +27,7 @@ export interface RecordGenerator {
  *
  * @group Arbitrary
  */
-export function record<T, K extends PropertyKey>(
+export function record<const T, K extends PropertyKey>(
     keyValue: Arbitrary<T> | [Arbitrary<K>, Arbitrary<T>],
     context: MaybePartial<RecordGenerator> = {},
 ): Dependent<Record<string, T>> {

--- a/src/random/types/set/set.spec.ts
+++ b/src/random/types/set/set.spec.ts
@@ -14,6 +14,7 @@ import { unknown } from '../complex/complex.js'
 import { integer } from '../integer/integer.js'
 
 import { describe, expect, expectTypeOf, it } from 'vitest'
+import { constants } from '../constants/constants.js'
 
 describe('set', () => {
     it('all unique - number', () => {
@@ -49,7 +50,59 @@ describe('set', () => {
             forAll(set(integer({ min: 1332584308, max: 1332584308 }), { minLength: 2 }), (xs) => {
                 return xs.length !== 2 && collect(unique(xs)).length === 2
             }),
-        ).toThrowErrorMatchingInlineSnapshot('[Tree is found infeasible]')
+        ).toThrowErrorMatchingInlineSnapshot('[Error: The minimum value must be less than the maximum value, and be finite]')
+    })
+
+    it('random sample', () => {
+        const ctx = arbitraryContext({ rng: xoroshiro128plus(1638968569864n) })
+        const aint = set(integer({ min: 0, max: 1 }))
+        expect(
+            collect(
+                take(
+                    repeat(() => aint.sample(ctx)),
+                    10,
+                ),
+            ),
+        ).toMatchInlineSnapshot(`
+          [
+            [
+              0,
+            ],
+            [
+              0,
+            ],
+            [
+              0,
+              1,
+            ],
+            [],
+            [
+              0,
+              1,
+            ],
+            [
+              1,
+            ],
+            [
+              1,
+              0,
+            ],
+            [
+              0,
+            ],
+            [
+              0,
+            ],
+            [
+              1,
+              0,
+            ],
+          ]
+        `)
+    }, 10)
+
+    it('cardinality', () => {
+        expect(set(constants('foo', 'bar')).supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('undefined')
     })
 })
 

--- a/src/random/types/set/set.ts
+++ b/src/random/types/set/set.ts
@@ -65,8 +65,19 @@ export function set<T, Min extends number = number>(
             return !xs.some((x) => eq(y, x))
         },
         arbitrary,
-        { minLength, maxLength, size },
+        {
+            minLength,
+            maxLength,
+            size,
+            cardinality: (x, ctx) => {
+                if (arbitrary.supremumCardinality !== undefined) {
+                    return Math.min(x, arbitrary.supremumCardinality(ctx))
+                }
+                return x
+            },
+        },
     )
+
     return dependentArbitrary((ctx) => {
         // make sure we don't shrink to an array with duplicates
         // biome-ignore lint/suspicious/noExplicitAny: end recursive type evaluation

--- a/src/random/types/string/string.spec.ts
+++ b/src/random/types/string/string.spec.ts
@@ -96,6 +96,10 @@ describe('string', () => {
     it('all printable', () => {
         forAll(string({ minLength: 1 }), isPrintable)
     })
+
+    it('cardinality', () => {
+        expect(string().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('950')
+    })
 })
 
 describe('hex', () => {
@@ -165,6 +169,10 @@ describe('hex', () => {
     it('allowed characters', () => {
         forAll(hex(), (str) => str.split('').every((c) => '0123456789abcdef'.includes(c)))
     })
+
+    it('cardinality', () => {
+        expect(hex().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('160')
+    })
 })
 
 describe('base64', () => {
@@ -211,6 +219,10 @@ describe('base64', () => {
         forAll(base64(), (str) =>
             str.split('').every((c) => 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='.includes(c)),
         )
+    })
+
+    it('cardinality', () => {
+        expect(base64().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('640')
     })
 })
 
@@ -289,6 +301,10 @@ describe('alpha', () => {
                 str.split('').every((c) => `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz${extra}`.includes(c)),
         )
     })
+
+    it('cardinality', () => {
+        expect(alpha().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('520')
+    })
 })
 
 describe('lowerAlpha', () => {
@@ -364,6 +380,10 @@ describe('lowerAlpha', () => {
             utf16().chain((extra) => lowerAlpha({ extra }).map((c) => [c, extra] as const)),
             ([str, extra]) => str.split('').every((c) => `abcdefghijklmnopqrstuvwxy${extra}`.includes(c)),
         )
+    })
+
+    it('cardinality', () => {
+        expect(alpha().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('520')
     })
 })
 
@@ -444,6 +464,10 @@ describe('alphaNumeric', () => {
                 str.split('').every((c) => `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789${extra}`.includes(c)),
         )
     })
+
+    it('cardinality', () => {
+        expect(alphaNumeric().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('620')
+    })
 })
 
 describe('lowerAlphaNumeric', () => {
@@ -520,6 +544,10 @@ describe('lowerAlphaNumeric', () => {
             ([str, extra]) => str.split('').every((c) => `abcdefghijklmnopqrstuvwxyz0123456789${extra}`.includes(c)),
         )
     })
+
+    it('cardinality', () => {
+        expect(lowerAlphaNumeric().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('360')
+    })
 })
 
 describe('ascii', () => {
@@ -590,6 +618,10 @@ describe('ascii', () => {
         // biome-ignore lint/suspicious/noControlCharactersInRegex: This is a valid use case for control characters
         forAll(ascii(), (str) => str.split('').every((c) => /[\x00-\x7F]/.test(c)))
     })
+
+    it('cardinality', () => {
+        expect(ascii().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('1270')
+    })
 })
 
 describe('utf16', () => {
@@ -639,6 +671,10 @@ describe('utf16', () => {
     it('allowed characters', () => {
         forAll(utf16(), (str) => util.toUSVString(str) === str)
     })
+
+    it('cardinality', () => {
+        expect(utf16().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('655360')
+    })
 })
 
 describe('utf16Surrogate', () => {
@@ -685,5 +721,9 @@ describe('utf16Surrogate', () => {
 
     it('allowed characters', () => {
         forAll(utf16Surrogate(), (str) => util.toUSVString(str) === str)
+    })
+
+    it('cardinality', () => {
+        expect(utf16Surrogate().supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('11141120')
     })
 })

--- a/src/random/types/tuple/tuple.spec.ts
+++ b/src/random/types/tuple/tuple.spec.ts
@@ -120,3 +120,7 @@ it('show small tree - integers', () => {
     const tree1 = arb.value(ctx)
     expect(showTree(tree1, { maxDepth: 2 })).toMatchSnapshot()
 })
+
+it('cardinality', () => {
+    expect(tuple(integer(), integer()).supremumCardinality?.(arbitraryContext())).toMatchInlineSnapshot('18446744082299486000')
+})


### PR DESCRIPTION
This pull request updates the arbitrary types to include a new property called "supremumCardinality" which calculates the maximum number of possible values for the arbitrary. This change affects various arbitrary types such as tuple, string, set, object, array, boolean, char, constants, date, and integer. The new property is used to provide better estimations for the maximum number of generated values in a given context.

---

